### PR TITLE
Init dot env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN apk add --no-cache \
     nginx \
     oniguruma \
     postgresql-libs \
-    sed
+    sed \
+    shadow
 
 # Set working directory
 WORKDIR /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN sed -i '/REDIS_PASSWORD/ a\            '\''username'\'' => env('\''REDIS_USE
 # Set permissions
 RUN mkdir -p /var/lib/nginx/logs /var/lib/nginx/tmp /var/cache/nginx  /var/run/nginx && touch /var/run/nginx.pid && touch /etc/nginx/nginx.conf
 RUN chown -R www-data:www-data /var/lib/nginx /var/www/html /var/cache/nginx /var/log/nginx /var/run/nginx /var/run/nginx.pid /etc/nginx/nginx.conf
-USER www-data
 RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
+USER www-data
 
 # Copy nginx configuration + start script into the container
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN sed -i '/REDIS_PASSWORD/ a\            '\''username'\'' => env('\''REDIS_USE
 RUN mkdir -p /var/lib/nginx/logs /var/lib/nginx/tmp /var/cache/nginx  /var/run/nginx && touch /var/run/nginx.pid && touch /etc/nginx/nginx.conf
 RUN chown -R www-data:www-data /var/lib/nginx /var/www/html /var/cache/nginx /var/log/nginx /var/run/nginx /var/run/nginx.pid /etc/nginx/nginx.conf
 USER www-data
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
 
 # Copy nginx configuration + start script into the container
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,9 @@ http {
 
         location ~ \.php$ {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_param HTTPS $http_x_forwarded_proto;
+            fastcgi_param HTTP_HOST $host;
+            fastcgi_param SERVER_PORT 443;
             fastcgi_pass 127.0.0.1:9000;
             fastcgi_index index.php;
             include fastcgi_params;

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,24 @@
 #!/bin/sh
 
+# Check if the .env file exists
+if [ ! -f /var/www/html/.env ]; then
+  echo "Creating /var/www/html/.env file with current environment variables..."
+  
+  # Write all environment variables to the .env file
+  printenv | while IFS= read -r line; do
+    # Escape special characters in variable values to ensure compatibility
+    key=$(echo "$line" | cut -d'=' -f1)
+    value=$(echo "$line" | cut -d'=' -f2- | sed 's/"/\\"/g')
+    
+    # Append to the .env file
+    echo "$key=\"$value\"" >> /var/www/html/.env
+  done
+
+  echo "/var/www/html/.env file created successfully."
+else
+  echo "/var/www/html/.env already exists. Skipping creation."
+fi
+
 # Start PHP-FPM in the background
 php-fpm &
 


### PR DESCRIPTION
If `/var/www/html/.env` doesn't exist, it will get created by pulling in all of the current environment variables available in the container.

This will allow us to use a ConfigMap and Secret in the Kubernetes pod to populate env vars instead of mounting a file into the container. Mounting a file into the container will remain an option, as this step does not overwrite the file if it exists at startup.