### PR TITLE
Copy default (stock) images to mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ WORKDIR /var/www/html
 
 # Copy application files
 COPY --from=build /var/www/html /var/www/html
+COPY --from=build /var/www/html/storage/app/public /var/www/html/storage/app/public-stock
 
 # Modify `config/database.php` and `config/cache.php` to add REDIS_USERNAME and REDIS_PREFIX after REDIS_PASSWORD
 RUN sed -i '/REDIS_PASSWORD/ a\            '\''username'\'' => env('\''REDIS_USERNAME'\'', null),' /var/www/html/config/database.php \

--- a/start.sh
+++ b/start.sh
@@ -19,6 +19,9 @@ else
   echo "/var/www/html/.env already exists. Skipping creation."
 fi
 
+# Copy over Pixelfed's stock images (header image, empty avatar etc) since we've mounted the public volume
+cp -r /var/www/html/storage/app/public-stock/* /var/www/html/storage/app/public
+
 # Start PHP-FPM in the background
 php-fpm &
 


### PR DESCRIPTION
Since we'll mount a volume to `/var/www/html/storage/app/public` at runtime, this copies the original Pixelfed source images to a separate folder `/var/www/html/storage/app/public-stock` at build time, and then copies them back in to the mounted volume on container startup.