### PR TITLE
Skip creating secret

### DIFF
--- a/charts/pixelfed/templates/secret.yaml
+++ b/charts/pixelfed/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.createSecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -39,3 +40,4 @@ data:
   REDIS_PREFIX: {{ .Values.config.REDIS_PREFIX | quote }}
   REDIS_SCHEME: {{ .Values.config.REDIS_SCHEME | quote }}
   REDIS_USERNAME: {{ .Values.config.REDIS_USERNAME | quote }}
+{{- end }}

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -1,6 +1,7 @@
 image:
   repo: "ghcr.io/grrywlsn/pixelfed-helm"
   tag: "v1.0.1"
+createSecret: false
 config:
   # Domain and session config
   # ADMIN_DOMAIN: Defaults to APP_DOMAIN


### PR DESCRIPTION
Adds `.values.createSecret` defaulting to `false`, assuming a Secret will be provided by another option like External-Secrets 