### PR TITLE
make Ingress optional

### DIFF
--- a/charts/pixelfed/templates/ingress.yaml
+++ b/charts/pixelfed/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,3 +25,4 @@ spec:
     - hosts:
         - {{ required "config.domain.APP_DOMAIN is required but missing" .Values.config.domain.APP_DOMAIN | quote }}
       secretName: "{{ include "pixelfed.fullname" . }}-tls"
+{{- end }}

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -3,6 +3,9 @@ image:
   repo: "ghcr.io/grrywlsn/pixelfed-helm"
   # -- version of the image to pull
   tag: "v3.8.2"
+ingress:
+  # -- Whether to create an Ingress resource for the Pixelfed server
+  enabled: true
 # -- The name of a secret to use instead of generating it from input values
 existingSecret: ""
 resources:


### PR DESCRIPTION
Add a new environment variable to disable creation of an `Ingress` source, for services moving to API Gateway.