### PR TITLE
Skip passport:keys when Passport keys come from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ Required:
 - APP_NAME: "Pixelfed"
 - APP_URL: "https://pixelfed.social"
 - INSTANCE_CONTACT_EMAIL: "help@pixelfed.social"
+
+## Laravel Passport (OAuth / mobile apps)
+
+Passport signing keys must stay stable across pod restarts. Put PEMs in your Kubernetes `Secret` (for example via External Secrets from Scaleway Secrets Manager) as **`PASSPORT_PRIVATE_KEY`** and **`PASSPORT_PUBLIC_KEY`** — the full `-----BEGIN …-----` / `-----END …-----` blocks, one field per key. The chart mounts the secret with `envFrom`; Laravel reads them via `config/passport.php`.
+
+When **both** variables are set, the container `start.sh` skips `php artisan passport:keys` so keys are not regenerated. If either is missing, startup still runs `passport:keys --force` (file-based keys on ephemeral disk).
+
+For an **existing** instance, copy the current PEMs from the running container’s `storage/oauth-private.key` and `storage/oauth-public.key` so existing app tokens keep working. For a **new** install, generate once (any machine with PHP / the app image), then copy the files into the secret manager:
+
+```bash
+php artisan passport:keys --force
+# read storage/oauth-private.key and storage/oauth-public.key
+```

--- a/start.sh
+++ b/start.sh
@@ -19,13 +19,19 @@ php artisan storage:link
 php artisan migrate --force
 php artisan import:cities
 php artisan instance:actor
-php artisan passport:keys --force
+# Passport: use PASSPORT_PRIVATE_KEY / PASSPORT_PUBLIC_KEY from the environment (e.g. K8s
+# ExternalSecret) when set so keys are stable across restarts; otherwise generate files once.
+if [ -n "${PASSPORT_PRIVATE_KEY}" ] && [ -n "${PASSPORT_PUBLIC_KEY}" ]; then
+  echo "Passport keys supplied via environment; skipping passport:keys"
+else
+  php artisan passport:keys --force
+fi
 php artisan route:cache
 php artisan view:cache
 php artisan config:cache
 php artisan horizon:install
 
-if [[ -n "${PIXELFED_PUSHGATEWAY_KEY}" ]]; then
+if [ -n "${PIXELFED_PUSHGATEWAY_KEY}" ]; then
   php artisan app:push-gateway-refresh
 fi
 


### PR DESCRIPTION
## Summary

- `start.sh`: if `PASSPORT_PRIVATE_KEY` and `PASSPORT_PUBLIC_KEY` are both set (e.g. from a Kubernetes `Secret` synced by External Secrets), skip `php artisan passport:keys` so OAuth signing keys stay stable across pod restarts.
- Otherwise keep the existing `passport:keys --force` behaviour for installs that still rely on file-based keys.
- Replace bash-style `[[` with POSIX `[` in `start.sh` for `/bin/sh` compatibility.
- Document storing Passport PEMs in the synced secret in the root `README.md`.

## Test plan

- [ ] Merge with an appropriate **patch** (or minor) label so CI can tag and publish a new chart/image.
- [ ] After release, bump the Flux `HelmRelease` chart version (and rely on the new default `image.tag` from the chart, or pin explicitly) in `kubernetes-state` for instances that set `PASSPORT_*` in Scaleway / the synced secret.
- [ ] Confirm a pod with both env vars set logs `Passport keys supplied via environment; skipping passport:keys` and OAuth / mobile login still works.


Made with [Cursor](https://cursor.com)